### PR TITLE
Checks to see if the parent has the method getDimensions

### DIFF
--- a/src/SVGImage.php
+++ b/src/SVGImage.php
@@ -16,7 +16,13 @@ class SVGImage extends Image
     }
 
     public function getDimensions($dim = "string") {
-        if($this->getExtension()!='svg' || !$this->exists()) return parent::getDimensions($dim);
+        if($this->getExtension()!='svg' || !$this->exists()) {
+            try {
+                return parent::getDimensions($dim);
+            } catch(\Exception $e) {
+                return false;
+            }
+        }
 
         if($this->getField('Filename')) {
             $filePath = $this->getFullPath();


### PR DESCRIPTION
Fixes an issue where the report won't run due to the parent of an image not being an image and not having the getDimensions function.